### PR TITLE
左上の分割ウィンドウにキャレット表示している際に、他の分割ウインドウをマウスクリックしてもキャレットが切り替わらない

### DIFF
--- a/sakura_core/view/Caret.h
+++ b/sakura_core/view/Caret.h
@@ -126,7 +126,9 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	//                        サイズ変更                           //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-	void SetCaretSize(int nW, int nH) { sizeCaret.Set(nW, nH); }						// キャレットサイズを設定
+	void SetCaretSize(int nW, int nH) {
+    sizeCaret.Set(nW, nH);
+  }
 
 	
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/view/EditView.cpp
+++ b/sakura_core/view/EditView.cpp
@@ -144,8 +144,6 @@ BOOL EditView::Create(
 	bCurSearchUpdate = false;
 	nCurSearchKeySequence = -1;
 
-	nMyIndex = 0;
-
 	//	メニューバーへのメッセージ表示機能はEditWndへ移管
 
 	// 共有データ構造体のアドレスを返す


### PR DESCRIPTION
fixes #30 

EditView::Create においてメンバー名と同名の引数が存在し、メンバーを初期化するつもりのコードが引数を変更していたのが原因。後でその引数がメンバーに設定されるので。